### PR TITLE
[SKIP CI] Add Homebrew trust command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ curl https://storage.googleapis.com/ncci-releases/get.sh | bash
 Homebrew (latest stable version)
 
 ```bash
+brew trust bigbinary/tap
 brew install bigbinary/tap/ncci
 ```
 


### PR DESCRIPTION
## Summary\n- Add the Homebrew tap trust command before the install command in README.\n\n## Testing\n- Not run; README-only change.